### PR TITLE
Implement ViewAnalyticsUseCase and related interfaces

### DIFF
--- a/src/main/java/use_case/view_analytics/ViewAnalyticsDataAccessInterface.java
+++ b/src/main/java/use_case/view_analytics/ViewAnalyticsDataAccessInterface.java
@@ -1,0 +1,11 @@
+package use_case.view_analytics;
+
+import entity.DailyTaskSummary;
+import java.util.List;
+
+/**
+ * Interface for retrieving analytics-related data from repository.
+ */
+public interface ViewAnalyticsDataAccessInterface {
+    List<DailyTaskSummary> getSummariesForUser(String userId);
+}

--- a/src/main/java/use_case/view_analytics/ViewAnalyticsInputBoundary.java
+++ b/src/main/java/use_case/view_analytics/ViewAnalyticsInputBoundary.java
@@ -1,0 +1,8 @@
+package use_case.view_analytics;
+
+/**
+ * Input boundary interface for viewing analytics.
+ */
+public interface ViewAnalyticsInputBoundary {
+    void execute(ViewAnalyticsInputData inputData);
+}

--- a/src/main/java/use_case/view_analytics/ViewAnalyticsInputData.java
+++ b/src/main/java/use_case/view_analytics/ViewAnalyticsInputData.java
@@ -1,0 +1,16 @@
+package use_case.view_analytics;
+
+/**
+ * Input data for viewing analytics.
+ */
+public class ViewAnalyticsInputData {
+    private final String userId;
+
+    public ViewAnalyticsInputData(String userId) {
+        this.userId = userId;
+    }
+
+    public String getUserId() {
+        return userId;
+    }
+}

--- a/src/main/java/use_case/view_analytics/ViewAnalyticsOutputBoundary.java
+++ b/src/main/java/use_case/view_analytics/ViewAnalyticsOutputBoundary.java
@@ -1,0 +1,8 @@
+package use_case.view_analytics;
+
+/**
+ * Output boundary interface for presenting analytics.
+ */
+public interface ViewAnalyticsOutputBoundary {
+    void prepareSuccessView(ViewAnalyticsOutputData outputData);
+}

--- a/src/main/java/use_case/view_analytics/ViewAnalyticsOutputData.java
+++ b/src/main/java/use_case/view_analytics/ViewAnalyticsOutputData.java
@@ -1,0 +1,19 @@
+package use_case.view_analytics;
+
+import entity.DailyTaskSummary;
+import java.util.List;
+
+/**
+ * Output data containing task summaries for analytics.
+ */
+public class ViewAnalyticsOutputData {
+    private final List<DailyTaskSummary> summaries;
+
+    public ViewAnalyticsOutputData(List<DailyTaskSummary> summaries) {
+        this.summaries = summaries;
+    }
+
+    public List<DailyTaskSummary> getSummaries() {
+        return summaries;
+    }
+}

--- a/src/main/java/use_case/view_analytics/ViewAnalyticsUseCase.java
+++ b/src/main/java/use_case/view_analytics/ViewAnalyticsUseCase.java
@@ -1,4 +1,30 @@
 package use_case.view_analytics;
 
-public class ViewAnalyticsUseCase {
+import entity.DailyTaskSummary;
+import java.util.List;
+
+/**
+ * Application business logic for viewing analytics such as task summaries, completion rates, etc.
+ */
+public class ViewAnalyticsUseCase implements ViewAnalyticsInputBoundary {
+    private final ViewAnalyticsDataAccessInterface dataAccess;
+    private final ViewAnalyticsOutputBoundary presenter;
+
+    public ViewAnalyticsUseCase(ViewAnalyticsDataAccessInterface dataAccess,
+                                ViewAnalyticsOutputBoundary presenter) {
+        this.dataAccess = dataAccess;
+        this.presenter = presenter;
+    }
+
+    /**
+     * Executes the use case: gathers analytics from the data source
+     * and prepares it for the presenter layer.
+     */
+    @Override
+    public void execute(ViewAnalyticsInputData inputData) {
+        List<DailyTaskSummary> summaries = dataAccess.getSummariesForUser(inputData.getUserId());
+
+        ViewAnalyticsOutputData outputData = new ViewAnalyticsOutputData(summaries);
+        presenter.prepareSuccessView(outputData);
+    }
 }


### PR DESCRIPTION
- Added ViewAnalyticsUseCase to handle fetching and presenting user task analytics
- Defined input boundary (ViewAnalyticsInputBoundary) and input data (ViewAnalyticsInputData)
- Defined output boundary (ViewAnalyticsOutputBoundary) and output data (ViewAnalyticsOutputData)
- Added data access interface (ViewAnalyticsDataAccessInterface) for fetching daily task summaries
- Structured clean architecture flow for viewing analytics with clear separation of concerns
- Prepared groundwork for testing by enabling easy mocking of dependencies
